### PR TITLE
Add support for large object streams

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.5",
-        "mockery/mockery": "^0.9.5"
+        "mockery/mockery": "^0.9.5",
+        "mikey179/vfsStream": "^1.6.4"
     }
 }


### PR DESCRIPTION
Since the pull request #3 hasn't worked out, I have tried to implement this myself with the tests.

One difference from the premise in #3 is that I have used 100MB segments as suggested in the OVH documentation [here](https://www.ovh.com/us/g1951.optimised_method_uploading_files_object_storage). 

Perhaps we should have some kind of configuration based input to this (so that users can change it if they want more easily)?