### PR TITLE
Support DateTimeImmutable as lastModified property of an object

### DIFF
--- a/src/SwiftAdapter.php
+++ b/src/SwiftAdapter.php
@@ -280,11 +280,17 @@ class SwiftAdapter extends AbstractAdapter
         $name = $this->removePathPrefix($object->name);
         $mimetype = explode('; ', $object->contentType);
 
+        if ($object->lastModified instanceof \DateTimeInterface) {
+            $timestamp = $object->lastModified->getTimestamp();
+        } else {
+            $timestamp = strtotime($object->lastModified);
+        }
+
         return [
             'type'      => 'file',
             'dirname'   => Util::dirname($name),
             'path'      => $name,
-            'timestamp' => strtotime($object->lastModified),
+            'timestamp' => $timestamp,
             'mimetype'  => reset($mimetype),
             'size'      => $object->contentLength,
         ];

--- a/tests/SwiftAdapterTest.php
+++ b/tests/SwiftAdapterTest.php
@@ -68,7 +68,7 @@ class SwiftAdapterTest extends \PHPUnit_Framework_TestCase
             ]);
         }
     }
-    
+
     public function testWriteAndUpdateLargeStream()
     {
         foreach (['writeStream', 'updateStream'] as $method) {
@@ -311,5 +311,22 @@ class SwiftAdapterTest extends \PHPUnit_Framework_TestCase
                 'size' => 1234,
             ]);
         }
+    }
+
+    public function testGetTimestampDateTimeImmutable()
+    {
+        $time = new \DateTimeImmutable(date('Y-m-d'));
+        $this->object->shouldReceive('retrieve')->once();
+        $this->object->lastModified = $time;
+
+        $this->container
+            ->shouldReceive('getObject')
+            ->once()
+            ->with('hello')
+            ->andReturn($this->object);
+
+        $metadata = $this->adapter->getTimestamp('hello');
+
+        $this->assertEquals($time->getTimestamp(), $metadata['timestamp']);
     }
 }


### PR DESCRIPTION
As of php-opencloud/openstack v2.1.2/v3.0.2 this property is no longer a string. Please release this soon as the current state is broken.

See: https://github.com/php-opencloud/openstack/commit/8c1fe4c11a046504d838325bd42ebb4996b7b7e4#diff-cc852aa5ed18bf878cc8b4d6af8f4c28R58