### PR TITLE
Reduce requests needed for delete()

### DIFF
--- a/src/SwiftAdapter.php
+++ b/src/SwiftAdapter.php
@@ -114,7 +114,7 @@ class SwiftAdapter extends AbstractAdapter
      */
     public function delete($path)
     {
-        $object = $this->getObject($path);
+        $object = $this->getObjectInstance($path);
 
         try {
             $object->delete();
@@ -253,7 +253,23 @@ class SwiftAdapter extends AbstractAdapter
     }
 
     /**
-     * Get an object.
+     * Get an object instance.
+     *
+     * @param string $path
+     *
+     * @return StorageObject
+     */
+    protected function getObjectInstance($path)
+    {
+        $location = $this->applyPathPrefix($path);
+
+        $object = $this->container->getObject($location);
+
+        return $object;
+    }
+
+    /**
+     * Get an object instance and retrieve its metadata from storage.
      *
      * @param string $path
      *
@@ -261,9 +277,7 @@ class SwiftAdapter extends AbstractAdapter
      */
     protected function getObject($path)
     {
-        $location = $this->applyPathPrefix($path);
-
-        $object = $this->container->getObject($location);
+        $object = $this->getObjectInstance($path);
         $object->retrieve();
 
         return $object;

--- a/tests/SwiftAdapterTest.php
+++ b/tests/SwiftAdapterTest.php
@@ -3,6 +3,7 @@
 use GuzzleHttp\Psr7\Stream;
 use League\Flysystem\Config;
 use org\bovigo\vfs\vfsStream;
+use OpenStack\Common\Error\BadResponseError;
 use org\bovigo\vfs\content\LargeFileContent;
 use Nimbusoft\Flysystem\OpenStack\SwiftAdapter;
 
@@ -121,7 +122,7 @@ class SwiftAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testDelete()
     {
-        $this->object->shouldReceive('retrieve')->once();
+        $this->object->shouldNotReceive('retrieve');
         $this->object->shouldReceive('delete')->once();
 
         $this->container->shouldReceive('getObject')


### PR DESCRIPTION
This change adds a new `getObjectInstance` method which creates the Swift object but does not call `retrieve()`. It can be used for `delete()` where `retrieve()` is not required. This saves a `HEAD` request.

Background:
I observed calls to `delete()` which threw exceptions because the object to delete does not exist (any more). What I expected in this case was a returned `false` and no exception. The exception originated from `getObject()` which fails at the `retrieve()` call when the object does not exist. My first impulse was to move `getObject()` inside the `try catch` block but then I noticed that the `retrieve()` is not required for `delete()` in the first place.