### PR TITLE
Make behavior for large objects configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,22 @@ $adapter = new Nimbusoft\Flysystem\OpenStack\SwiftAdapter($container);
 
 $flysystem = new League\Flysystem\Filesystem($adapter);
 ```
+
+## Configuration
+
+The Swift adapter allows you to configure the behavior of uploading [large objects](https://php-opencloudopenstack.readthedocs.io/en/latest/services/object-store/v1/objects.html#create-a-large-object-over-5gb). You can set the following configuration options:
+
+- `swiftLargeObjectThreshold`: Size of the file in bytes when to switch over to the large object upload procedure. Default is 300 MiB. The maximum allowed size of regular objects is 5 GiB.
+- `swiftSegmentSize`: Size of individual segments or chunks that the large file is split up into. Default is 100 MiB. Should be below 5 GiB.
+- `swiftSegmentContainer`: Name of the Swift container to store the large object segments to. Default is the same container that stores the regular files.
+
+Example:
+
+```php
+
+$flysystem = new League\Flysystem\Filesystem($adapter, new \League\Flysystem\Config([
+    'swiftLargeObjectThreshold' => 104857600, // 100 MiB
+    'swiftSegmentSize' => 52428800, // 50 MiB
+    'swiftSegmentContainer' => 'mySegmentContainer',
+]));
+```

--- a/src/SwiftAdapter.php
+++ b/src/SwiftAdapter.php
@@ -51,11 +51,12 @@ class SwiftAdapter extends AbstractAdapter
 
         $data[$type] = $contents;
 
-        if ($type === 'stream' && $size > 314572800) {
-            // set the segment size to 100MB
-            // as suggested in OVH docs
-            $data['segmentSize'] = 104857600;
-            $data['segmentContainer'] = $this->container->name;
+        // Create large object if the stream is larger than 300 MiB (default).
+        if ($type === 'stream' && $size > $config->get('swiftLargeObjectThreshold', 314572800)) {
+            // Set the segment size to 100 MiB by default as suggested in OVH docs.
+            $data['segmentSize'] = $config->get('swiftSegmentSize', 104857600);
+            // Set segment container to the same container by default.
+            $data['segmentContainer'] = $config->get('swiftSegmentContainer', $this->container->name);
 
             $response = $this->container->createLargeObject($data);
         } else {


### PR DESCRIPTION
New configuration options are `swiftLargeObjectThreshold`, `swiftSegmentSize` and `swiftSegmentContainer`. They can be set like this:

```php
use League\Flysystem\Config;
use League\Flysystem\Filesystem;
use Nimbusoft\Flysystem\OpenStack\SwiftAdapter;

new Filesystem(new SwiftAdapter($container), new Config([
    'swiftLargeObjectThreshold' => 104857600, // 100 MiB
    'swiftSegmentSize' => 52428800, // 50 MiB
    'swiftSegmentContainer' => 'mySegmentContainer',
]));
```

I implemented this as I wanted to be able to change the default behavior of an arbitrary threshold of 300 MiB and a segment size of 100 MiB.