### PR TITLE
Provision for parameters in dependent implementation

### DIFF
--- a/src/SwiftAdapter.php
+++ b/src/SwiftAdapter.php
@@ -42,7 +42,7 @@ class SwiftAdapter extends AbstractAdapter
     {
         $path = $this->applyPathPrefix($path);
 
-        $data = $this->getData();
+        $data = $this->getData($path);
         $type = 'content';
 
         if (is_a($contents, 'GuzzleHttp\Psr7\Stream')) {
@@ -256,9 +256,11 @@ class SwiftAdapter extends AbstractAdapter
     /**
      * Get data properties of object
      *
+     * @param string $path
+     *
      * @return array
      */
-    protected function getData()
+    protected function getData($path)
     {
         return ['name' => $path];
     }

--- a/src/SwiftAdapter.php
+++ b/src/SwiftAdapter.php
@@ -42,7 +42,7 @@ class SwiftAdapter extends AbstractAdapter
     {
         $path = $this->applyPathPrefix($path);
 
-        $data = ['name' => $path];
+        $data = $this->getData();
         $type = 'content';
 
         if (is_a($contents, 'GuzzleHttp\Psr7\Stream')) {
@@ -253,6 +253,16 @@ class SwiftAdapter extends AbstractAdapter
         return $this->getMetadata($path);
     }
 
+    /**
+     * Get data properties of object
+     *
+     * @return array
+     */
+    protected function getData()
+    {
+        return ['name' => $path];
+    }
+    
     /**
      * Get an object instance.
      *


### PR DESCRIPTION
The current implementation does not allow for more parameters to be added to the object being upload (for eg, `deleteAfter`, `deleteAt` etc). See additional parameters [here](https://github.com/php-opencloud/openstack/blob/master/src/ObjectStore/v1/Params.php)

By having a method in the adapter, any dependent implementation (like [my package](https://github.com/sausin/laravel-ovh/)) can add these additional parameters, if required, by overriding the new `getData` method without having to change the base implementation of `write`, or `writeStream` methods