### PR TITLE
Allow passing size as option

### DIFF
--- a/src/SwiftAdapter.php
+++ b/src/SwiftAdapter.php
@@ -82,7 +82,13 @@ class SwiftAdapter implements FilesystemAdapter
             throw new InvalidArgumentException('The $contents parameter must be a resource.');
         }
 
-        $stream = $this->getStreamFromResource($contents);
+        $options = [];
+        $size = $config->get('size');
+        if (null !== $size) {
+            $options['size'] = $size;
+        }
+        $stream = $this->getStreamFromResource($contents, $options);
+
         $path = $this->prefixer->prefixPath($path);
         $data = $this->getWriteData($path, $config);
         $data['stream'] = $stream;
@@ -385,9 +391,9 @@ class SwiftAdapter implements FilesystemAdapter
     /**
      * @param resource $resource
      */
-    protected function getStreamFromResource($resource): Stream
+    protected function getStreamFromResource($resource, array $options = []): Stream
     {
-        return new Stream($resource);
+        return new Stream($resource, $options);
     }
 
     /**

--- a/src/SwiftAdapter.php
+++ b/src/SwiftAdapter.php
@@ -69,7 +69,7 @@ class SwiftAdapter implements FilesystemAdapter
         try {
             $this->container->createObject($data);
         } catch (BadResponseError $e) {
-            throw UnableToWriteFile::atLocation($path);
+            throw UnableToWriteFile::atLocation($path, $e->getMessage(), $e);
         }
     }
 
@@ -105,7 +105,7 @@ class SwiftAdapter implements FilesystemAdapter
                 $this->container->createObject($data);
             }
         } catch (BadResponseError $e) {
-            throw UnableToWriteFile::atLocation($path);
+            throw UnableToWriteFile::atLocation($path, $e->getMessage(), $e);
         }
     }
 

--- a/tests/SwiftAdapterTest.php
+++ b/tests/SwiftAdapterTest.php
@@ -507,7 +507,7 @@ class SwiftAdapterStub extends SwiftAdapter
 {
     public $streamMock;
 
-    protected function getStreamFromResource($resource): Stream
+    protected function getStreamFromResource($resource, array $options = []): Stream
     {
         return $this->streamMock;
     }


### PR DESCRIPTION
I've noticed that it's not always possible for the openstack package to determine the stream size for example when using php://input, it allows passing it however which allows us to get the size from the content-length header.

These changes allow passing along the stream size manually, so that the createLargeObject() method will be called for larger files.