### PR TITLE
DeleteAt/DeleteAfter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,23 +36,40 @@ $flysystem = new League\Flysystem\Filesystem($adapter);
 
 ## Configuration
 
-The Swift adapter allows you to configure the behavior of uploading [large objects](https://php-opencloudopenstack.readthedocs.io/en/latest/services/object-store/v1/objects.html#create-a-large-object-over-5gb) with `writeStream()`. You can set the following configuration options:
+The Swift adapter has the following configuration options:
 
+### Uploading large objects
+See more at [openstack documentation](https://php-opencloudopenstack.readthedocs.io/en/latest/services/object-store/v1/objects.html#create-a-large-object-over-5gb)
 - `swiftLargeObjectThreshold`: Size of the file in bytes when to switch over to the large object upload procedure. Default is 300 MiB. The maximum allowed size of regular objects is 5 GiB.
 - `swiftSegmentSize`: Size of individual segments or chunks that the large file is split up into. Default is 100 MiB. Should be below 5 GiB.
 - `swiftSegmentContainer`: Name of the Swift container to store the large object segments to. Default is the same container that stores the regular files.
 
-One can also set the object expiration time via either property:
+### Content type
+- `contentType`: Sets the Content-Type header of the request.
+- `detectContentType`: If set to true, Object Storage guesses the content type based on the file extension and ignores the value sent in the Content-Type header, if present.
+
+### File expiration
 - `deleteAfter`: Specifies the number of seconds after which the object is removed. Internally, the Object Storage system stores this value in the X-Delete-At metadata item.
 - `deleteAt`: The certain date, in the UNIX Epoch timestamp format, when the object will be removed.
 
-Example:
+
+### Examples
+These options can be set on `Filesystem` creation:
 
 ```php
-
 $flysystem = new League\Flysystem\Filesystem($adapter, new \League\Flysystem\Config([
     'swiftLargeObjectThreshold' => 104857600, // 100 MiB
     'swiftSegmentSize' => 52428800, // 50 MiB
     'swiftSegmentContainer' => 'mySegmentContainer',
 ]));
+```
+
+or per-file:
+
+```php
+$flysystem->write($path, $contents, new \League\Flysystem\Config([
+    'swiftLargeObjectThreshold' => 52428800, // 50 MiB
+    'contentType' => 'text/plain',
+    'deleteAfter' => 3600, // 1 hour
+])
 ```

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ The Swift adapter allows you to configure the behavior of uploading [large objec
 - `swiftSegmentSize`: Size of individual segments or chunks that the large file is split up into. Default is 100 MiB. Should be below 5 GiB.
 - `swiftSegmentContainer`: Name of the Swift container to store the large object segments to. Default is the same container that stores the regular files.
 
+One can also set the object expiration time via either property:
+- `deleteAfter`: Specifies the number of seconds after which the object is removed. Internally, the Object Storage system stores this value in the X-Delete-At metadata item.
+- `deleteAt`: The certain date, in the UNIX Epoch timestamp format, when the object will be removed.
+
 Example:
 
 ```php

--- a/src/SwiftAdapter.php
+++ b/src/SwiftAdapter.php
@@ -326,6 +326,14 @@ class SwiftAdapter implements FilesystemAdapter
             $data['detectContentType'] = $detectContentType;
         }
 
+        if ($deleteAt = $config->get('deleteAt')) {
+            $data['deleteAt'] = $deleteAt;
+        }
+
+        if ($deleteAfter = $config->get('deleteAfter')) {
+            $data['deleteAfter'] = $deleteAfter;
+        }
+
         return $data;
     }
 

--- a/src/SwiftAdapter.php
+++ b/src/SwiftAdapter.php
@@ -406,7 +406,7 @@ class SwiftAdapter implements FilesystemAdapter
         foreach ($objectList as $object) {
             // Strip the prefix from the path. We only want to augment directories from
             // the prefix down.
-            $path = explode('/', substr($object->name, $prefixLength));
+            $path = explode('/', (string)substr($object->name, $prefixLength));
             $filename = array_pop($path);
             $fullPath = '';
             foreach ($path as $part) {

--- a/tests/SwiftAdapterTest.php
+++ b/tests/SwiftAdapterTest.php
@@ -370,6 +370,47 @@ class SwiftAdapterTest extends TestCase
         $this->assertNull($response);
     }
 
+    public function testWriteDeleteAt()
+    {
+        $time = time() + 3600;
+        $this->container->shouldReceive('createObject')
+            ->once()
+            ->with([
+                'name' => 'hello',
+                'content' => 'world',
+                'deleteAt' => $time,
+            ])
+            ->andReturn($this->object);
+
+        $config = $this->config->extend([
+            'deleteAt' => $time
+        ]);
+
+        $response = $this->adapter->write('hello', 'world', $config);
+
+        $this->assertNull($response);
+    }
+
+    public function testWriteDeleteAfter()
+    {
+        $this->container->shouldReceive('createObject')
+            ->once()
+            ->with([
+                'name' => 'hello',
+                'content' => 'world',
+                'deleteAfter' => 3600,
+            ])
+            ->andReturn($this->object);
+
+        $config = $this->config->extend([
+            'deleteAfter' => 3600
+        ]);
+
+        $response = $this->adapter->write('hello', 'world', $config);
+
+        $this->assertNull($response);
+    }
+
     public function testWriteStream()
     {
         $stream = fopen('data://text/plain;base64,'.base64_encode('world'), 'r');


### PR DESCRIPTION
Adds support `deleteAt`/`deleteAfter` options. They allow automatically delete objects after some time. 
See https://github.com/php-opencloud/openstack/blob/master/src/ObjectStore/v1/Params.php#L360

Also added small fix for php 7.4